### PR TITLE
Add alaw codec

### DIFF
--- a/nmf_converter.py
+++ b/nmf_converter.py
@@ -21,7 +21,7 @@ codecs = {
     0: "g729",
     1: "adpcm_g726",
     2: "adpcm_g726",
-	3: "alaw",
+    3: "alaw",
     7: "pcm_mulaw",
     8: "g729",
     9: "g723_1",

--- a/nmf_converter.py
+++ b/nmf_converter.py
@@ -21,6 +21,7 @@ codecs = {
     0: "g729",
     1: "adpcm_g726",
     2: "adpcm_g726",
+	3: "alaw",
     7: "pcm_mulaw",
     8: "g729",
     9: "g723_1",


### PR DESCRIPTION
We found the codec needed for '3' was alaw.  Not sure how to implement the 44.1khz-->8khz conversion without also messing up the rest of your elegant python, but I wanted to contribute this back.